### PR TITLE
Use json-stable-stringify for deterministic JSON files and specify typescript as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,14 +25,19 @@
     "testing"
   ],
   "dependencies": {
+    "json-stable-stringify": "^1.0.1",
     "lodash.escaperegexp": "^4.1.2",
     "nock": "^9.0.13",
     "pkg-conf": "^2.0.0",
     "shorthash": "^0.0.2"
   },
   "devDependencies": {
+    "@types/json-stable-stringify": "^1.0.31",
     "@types/lodash.escaperegexp": "^4.1.2",
     "@types/nock": "^8.2.1",
     "@types/node": "^7.0.18"
+  },
+  "peerDependencies": {
+    "typescript": "^2.3.2"
   }
 }

--- a/src/record.ts
+++ b/src/record.ts
@@ -2,6 +2,7 @@ import * as nock from 'nock'
 import * as path from 'path'
 import * as sh from 'shorthash'
 import * as fs from 'fs'
+import * as stringify from 'json-stable-stringify'
 
 const bind = (f: Function, ...args: any[]) => f.bind(null, ...args)
 
@@ -17,7 +18,7 @@ const saveRecord = (collection: string, record: nock.NockDefinition) => {
   if (!fs.existsSync(scopeFolder)) fs.mkdirSync(scopeFolder)
   const recordPath = path.join(scopeFolder, recordName(record))
   if (fs.existsSync(recordPath)) return
-  fs.writeFileSync(recordPath, JSON.stringify(record, null, 2), { encoding: 'utf8' })
+  fs.writeFileSync(recordPath, stringify(record, { space: 2 }), { encoding: 'utf8' })
 }
 
 const onMessage = (message: string, cb: () => void) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@types/json-stable-stringify@^1.0.31":
+  version "1.0.31"
+  resolved "https://registry.yarnpkg.com/@types/json-stable-stringify/-/json-stable-stringify-1.0.31.tgz#b6c7bc507f5267e88cd2839b3ac6a2b39b653a32"
+
 "@types/lodash.escaperegexp@^4.1.2":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@types/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz#3e878d4b8f44c0304cb0280ab946e4c5eee0e8eb"
@@ -50,6 +54,10 @@ deep-equal@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
+dom-walk@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -70,9 +78,19 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
+json-stable-stringify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
+  dependencies:
+    jsonify "~0.0.0"
+
 json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
+
+jsonify@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
 load-json-file@^2.0.0:
   version "2.0.0"
@@ -97,6 +115,12 @@ lodash.escaperegexp@^4.1.2:
 lodash@~4.17.2:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+min-document@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
+  dependencies:
+    dom-walk "^0.1.0"
 
 minimist@0.0.8:
   version "0.0.8"
@@ -156,6 +180,10 @@ pkg-conf@^2.0.0:
     find-up "^2.0.0"
     load-json-file "^2.0.0"
 
+process@~0.5.1:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
+
 propagate@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
@@ -179,3 +207,7 @@ type-detect@0.1.1:
 type-detect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-1.0.0.tgz#762217cc06db258ec48908a1298e8b95121e8ea2"
+
+typescript@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"


### PR DESCRIPTION
One thing I've learned from doing very similar work on Jest is that the recording of VCR files can cause a lot of churn. When files are updated they often don't contain any real changes but are simply written with the keys in a different order.

Using json-stable-stringify helps a bit with this to reduce some churn so I made this PR for that.